### PR TITLE
[16.0][FIX] sale_rental: fix create a duplicate sale.rental when reconfirming

### DIFF
--- a/sale_rental/models/sale_order.py
+++ b/sale_rental/models/sale_order.py
@@ -177,6 +177,17 @@ class SaleOrderLine(models.Model):
         ]
         self.env["procurement.group"].run(procurements)
 
+    def _create_sale_rental(self, order_line):
+        existing_rental = self.env["sale.rental"].search(
+            [
+                ("start_order_line_id", "=", order_line.id),
+            ],
+            limit=1,
+        )
+
+        if not existing_rental:
+            self.env["sale.rental"].create(order_line._prepare_rental())
+
     def _action_launch_stock_rule(self, previous_product_uom_qty=False):
         errors = []
         for line in self:
@@ -199,7 +210,7 @@ class SaleOrderLine(models.Model):
                 except UserError as error:
                     errors.append(error.name)
 
-                self.env["sale.rental"].create(line._prepare_rental())
+                self._create_sale_rental(line)
 
             elif (
                 line.rental_type == "rental_extension"


### PR DESCRIPTION
Rental record is generated incorrectly when reconfirming a cancelled sale order with rental products

Steps to Reproduce:
1. Create and Confirm a Sale Order containing rental products.
2. Cancel the Sale Order, set to Quotation and re-confirm a Sale Order
3. You can see duplicate Sale Rental
<img width="1289" height="241" alt="image" src="https://github.com/user-attachments/assets/6b5bdecb-1cf3-4d18-8feb-7a02d02ca801" />

Fixes:
When confirm order, check existing Sale Rental with `sale.order.line` id. If not existing, create a new Sale Rental